### PR TITLE
Add env example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+WORDPRESS_URL=your-wordpress-url
+WORDPRESS_USER=your-username
+WORDPRESS_PASS=your-password

--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ cp .env.example .env
 
 ## Configuration
 
-Create a `.env` file with the following variables:
+Copy `.env.example` to `.env` and update the values:
+```
+cp .env.example .env
+```
+
+The `.env` file should contain the following variables:
 ```
 WORDPRESS_URL=your-wordpress-site/wp-json/wp/v2/posts
 WORDPRESS_USER=your-username


### PR DESCRIPTION
## Summary
- add `.env.example` template for WordPress credentials
- update README config instructions to reference the example file

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6845d0ad6a088324a24799e5a067a87c